### PR TITLE
fixed a bug in ordered_populations()

### DIFF
--- a/xrsdkit/__init__.py
+++ b/xrsdkit/__init__.py
@@ -494,14 +494,16 @@ def update_populations(pops,new_pops):
 
 def ordered_populations(pops):
     opd = OrderedDict()
-    ## Step 1: Standardize order of populations by structure,
-    ## excluding hypothetical entries for noise or unidentified structures
+    ## Step 1: Standardize order of populations by structure and form,
+    ## excluding entries for noise or unidentified structures
     for stnm in structure_names:
-        for pop_nm,popdef in pops.items():
-            if not pop_nm == 'noise' \
-            and not popdef['structure'] == 'unidentified':
-                if popdef['structure'] == stnm:
-                    opd[pop_nm] = copy.deepcopy(popdef)
+	for ffnm in form_factor_names:
+	        for pop_nm,popdef in pops.items():
+        	    if not pop_nm == 'noise' \
+	            and not popdef['structure'] == 'unidentified':
+        	        if popdef['structure'] == stnm \
+			and ffnm in [popdef['basis'][sitenm]['form'] for sitenm in popdef['basis'].keys():
+                	    opd[pop_nm] = copy.deepcopy(popdef)
     ## Step 2: Standardize order of sites by form factor
     for pop_nm,popdef in opd.items():
         obd = OrderedDict()

--- a/xrsdkit/__init__.py
+++ b/xrsdkit/__init__.py
@@ -502,7 +502,7 @@ def ordered_populations(pops):
         	    if not pop_nm == 'noise' \
 	            and not popdef['structure'] == 'unidentified':
         	        if popdef['structure'] == stnm \
-			and ffnm in [popdef['basis'][sitenm]['form'] for sitenm in popdef['basis'].keys():
+			and ffnm in [popdef['basis'][sitenm]['form'] for sitenm in popdef['basis'].keys()]:
                 	    opd[pop_nm] = copy.deepcopy(popdef)
     ## Step 2: Standardize order of sites by form factor
     for pop_nm,popdef in opd.items():

--- a/xrsdkit/__init__.py
+++ b/xrsdkit/__init__.py
@@ -497,13 +497,13 @@ def ordered_populations(pops):
     ## Step 1: Standardize order of populations by structure and form,
     ## excluding entries for noise or unidentified structures
     for stnm in structure_names:
-	for ffnm in form_factor_names:
-	        for pop_nm,popdef in pops.items():
-        	    if not pop_nm == 'noise' \
-	            and not popdef['structure'] == 'unidentified':
-        	        if popdef['structure'] == stnm \
-			and ffnm in [popdef['basis'][sitenm]['form'] for sitenm in popdef['basis'].keys()]:
-                	    opd[pop_nm] = copy.deepcopy(popdef)
+        for ffnm in form_factor_names:
+            for pop_nm,popdef in pops.items():
+                if not pop_nm == 'noise' \
+                and not popdef['structure'] == 'unidentified':
+                    if popdef['structure'] == stnm \
+                    and ffnm in [popdef['basis'][sitenm]['form'] for sitenm in popdef['basis'].keys()]:
+                        opd[pop_nm] = copy.deepcopy(popdef)
     ## Step 2: Standardize order of sites by form factor
     for pop_nm,popdef in opd.items():
         obd = OrderedDict()


### PR DESCRIPTION
@Katy-katy 

This is a bug that will affect the model-building process. When a populations dict is processed, it should be ordered according to its structure and form factors, but I had only ordered it according to structure factors. This might reduce the number of classes for the system classifier and also the number of regression models per system.