### PR TITLE
shuffling bug was fixed

### DIFF
--- a/xrsdkit/models/xrsd_model.py
+++ b/xrsdkit/models/xrsd_model.py
@@ -1,6 +1,6 @@
 import numpy as np
 import yaml
-from sklearn import model_selection, preprocessing
+from sklearn import model_selection, preprocessing, utils
 from dask_ml.model_selection import GridSearchCV
 
 from ..tools import profiler
@@ -59,9 +59,8 @@ class XRSDModel(object):
             return
         else:
             # NOTE: SGD models train more efficiently on shuffled data
-            shuffled_rows = np.random.permutation(all_data.index)
-            all_data = all_data.loc[shuffled_rows]
-            data = all_data[all_data[self.target].isnull() == False]
+            d = utils.shuffle(d)
+            data = d[d[self.target].isnull() == False]
             data = self.standardize(data)
 
             if hyper_parameters_search:


### PR DESCRIPTION
We had a bug: the number of rows before and after shuffling was different. It looks like it was caused by using indexes for shuffling. We also did not use "d" - the data frame that was returned by  self.check_label(all_data). This data frame includes at least 3 samples for each class: we need it when we are using 3 folders cross-validation.  