### PR TITLE
matplotlib fix for mac

### DIFF
--- a/xrsdkit/__init__.py
+++ b/xrsdkit/__init__.py
@@ -1,4 +1,8 @@
 """xrsdkit: a package for data-driven scattering and diffraction analysis"""
-
+import os
+from sys import platform as sys_pf
+import matplotlib
+if 'DISPLAY' in os.environ or sys_pf == 'darwin':
+    matplotlib.use("TkAgg")
 # API will be defined here
 

--- a/xrsdkit/visualization/gui.py
+++ b/xrsdkit/visualization/gui.py
@@ -9,8 +9,7 @@ from ..models import predict as xrsdpred
 
 import numpy as np
 import matplotlib
-if 'DISPLAY' in os.environ:
-    matplotlib.use("TkAgg")
+
 mplv = matplotlib.__version__
 mplvmaj = int(mplv.split('.')[0])
 from matplotlib.figure import Figure


### PR DESCRIPTION
@lensonp I got a new MacPro and in the process of migrating my work from my old Mac to my new Mac I realized that we still have a problem with running gui on MacOS (macOS backend does not work with some matplotlib packages). I tried to put:

if 'DISPLAY' in os.environ or sys_pf == 'darwin':
    matplotlib.use("TkAgg")

in **gui.py**, but it did not work. We need to have these lines before any import of matplotlib or its parts. I did not find where we import it in the first time, so I put in into **xrsdkit.__init__**. Now it works.