### PR TITLE
can now select model types for specific models

### DIFF
--- a/xrsdkit/models/classifier.py
+++ b/xrsdkit/models/classifier.py
@@ -25,7 +25,7 @@ class Classifier(XRSDModel):
                 )
             )        
 
-    def build_model(self,model_type='logistic_regressor',model_hyperparams={}):
+    def build_model(self,model_hyperparams={}):
         if self.model_type ==  'logistic_regressor':
             penalty='l2'
             if 'penalty' in model_hyperparams: penalty = model_hyperparams['penalty']

--- a/xrsdkit/models/xrsd_model.py
+++ b/xrsdkit/models/xrsd_model.py
@@ -128,7 +128,7 @@ class XRSDModel(object):
             # begin by recursively eliminating features on a simple model
             model_feats = copy.deepcopy(profiler.profile_keys)
             if select_features:
-                model_feats = self.cross_validation_rfe(model_type,valid_data,model_feats)
+                model_feats = self.cross_validation_rfe(valid_data,model_feats)
                 test_model = self.build_model()
                 test_model.fit(valid_data[model_feats], valid_data[self.target])
                 cv = self.run_cross_validation(test_model,valid_data,model_feats)
@@ -141,7 +141,7 @@ class XRSDModel(object):
             model_hyperparams = {}
             if train_hyperparameters:
                 test_model = self.build_model()
-                param_grid = self.models_and_params[model_type]
+                param_grid = self.models_and_params[self.model_type]
                 #test_model = self.build_sgd_model()
                 #param_grid = self.sgd_hyperparam_grid
                 model_hyperparams = self.grid_search_hyperparams(test_model,valid_data,model_feats,param_grid,scoring)


### PR DESCRIPTION
This is primarily intended to help us develop better models, so that we can focus on improving specific models without impacting the others.

We can now specify which model to train in xrsdkit.models.train.train_classifiers and xrsdkit.models.train.train_regressors. In these functions, there are several spots where the model type is specified, e.g.:
    new_model_type = 'logistic_regressor'

If the new_model_type is changed to one of the modeling options in xrsdkit.models.regressor.Regressor.models_and_params.keys(),
or xrsdkit.models.classifier.Classifier.models_and_params.keys(),
it should train seamlessly for the new model type.