### PR TITLE
Summary cleanup

### DIFF
--- a/tests/test_data_modeling.py
+++ b/tests/test_data_modeling.py
@@ -10,17 +10,16 @@ from xrsdkit.models.predict import predict, system_from_prediction
 from xrsdkit.visualization import visualize_dataframe
 from xrsdkit.visualization.gui import run_fit_gui 
 
-datapath = os.path.join(os.path.dirname(__file__),
-        'test_data','dataset.csv')
+data_dir = os.path.join(os.path.dirname(__file__),'test_data')
+dataset_path = os.path.join(data_dir,'dataset.csv')
 
-src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-testing_data_dir = os.path.join(src_dir,'xrsdkit','models','modeling_data', 'test')
-if not os.path.exists(testing_data_dir): os.mkdir(testing_data_dir)
+test_models_dir = os.path.join(data_dir,'modeling_data')
+if not os.path.exists(test_models_dir): os.mkdir(test_models_dir)
 
 df = None
-if os.path.exists(datapath):
-    print('loading cached dataset from {}'.format(datapath))
-    df = pd.read_csv(datapath)
+if os.path.exists(dataset_path):
+    print('loading cached dataset from {}'.format(dataset_path))
+    df = pd.read_csv(dataset_path)
 
 def test_visualization():
     if df is not None and 'DISPLAY' in os.environ:
@@ -36,8 +35,8 @@ df_ds = downsample_df()
 
 # test prediction on loaded models
 def test_predict_0():
-    datapath = os.path.join(os.path.dirname(__file__),
-        'test_data','solution_saxs','spheres','spheres_0.dat')
+    datapath = os.path.join(data_dir,
+        'solution_saxs','spheres','spheres_0.dat')
     sysfpath = os.path.splitext(datapath)[0]+'.yml'
     f = open(datapath,'r')
     q_I = np.loadtxt(f,dtype=float)
@@ -51,13 +50,12 @@ def test_predict_0():
 # train new models
 def test_training():
     if df_ds is not None:
-        #train_from_dataframe(df_ds,train_hyperparameters=True,select_features=True,save_models=True,test=True)
-        train_from_dataframe(df_ds,testing_data_dir, train_hyperparameters=False,select_features=False,save_models=True)
+        train_from_dataframe(df_ds,test_models_dir,train_hyperparameters=False,select_features=False,save_models=True)
 
 # test prediction on newly trained models
 def test_predict_1():
-    datapath = os.path.join(os.path.dirname(__file__),
-        'test_data','solution_saxs','spheres','spheres_0.dat')
+    datapath = os.path.join(data_dir,
+        'solution_saxs','spheres','spheres_0.dat')
     sysfpath = os.path.splitext(datapath)[0]+'.yml'
     f = open(datapath,'r')
     q_I = np.loadtxt(f,dtype=float)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,9 +6,8 @@ from xrsdkit.db import load_yml_to_file_table, load_from_files_table_to_samples_
 from xrsdkit.db import load_from_samples_to_training_table, get_training_dataframe
 from xrsdkit.db import storage_client, storage_path, test_db_connector
 
-src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-testing_data_dir = os.path.join(src_dir,'xrsdkit','models','modeling_data', 'test')
-if not os.path.exists(testing_data_dir): os.mkdir(testing_data_dir)
+test_models_dir = os.path.join(data_dir,'modeling_data')
+if not os.path.exists(test_models_dir): os.mkdir(test_models_dir)
 
 def test_load_yml_to_file_table():
     if test_db_connector and storage_client and storage_path:
@@ -30,5 +29,5 @@ def test_get_training_dataframe():
 def test_if_the_result_is_trainable():
     if df:
         df_sample = downsample_by_group(df)
-        train_from_dataframe(df_sample,testing_data_dir)
+        train_from_dataframe(df_sample,test_models_dir)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,6 +6,7 @@ from xrsdkit.db import load_yml_to_file_table, load_from_files_table_to_samples_
 from xrsdkit.db import load_from_samples_to_training_table, get_training_dataframe
 from xrsdkit.db import storage_client, storage_path, test_db_connector
 
+data_dir = os.path.join(os.path.dirname(__file__),'test_data')
 test_models_dir = os.path.join(data_dir,'modeling_data')
 if not os.path.exists(test_models_dir): os.mkdir(test_models_dir)
 

--- a/xrsdkit/models/__init__.py
+++ b/xrsdkit/models/__init__.py
@@ -8,19 +8,17 @@ from .regressor import Regressor
 from .classifier import Classifier
 
 file_path = os.path.abspath(__file__)
-src_dir = os.path.dirname(os.path.dirname(file_path))
-root_dir = os.path.dirname(src_dir)
+models_dir = os.path.dirname(file_path)
+package_dir = os.path.dirname(models_dir)
+#root_dir = os.path.dirname(package_dir)
 
 # find directory containing packaged modeling data
-modeling_data_dir = os.path.join(src_dir,'models','modeling_data')
+modeling_data_dir = os.path.join(package_dir,'models','modeling_data')
 regression_models_dir = os.path.join(modeling_data_dir,'regressors')
 classification_models_dir = os.path.join(modeling_data_dir,'classifiers')
 
-# find directory containing test modeling data
-testing_data_dir = os.path.join(src_dir,'models','modeling_data','test')
-if not os.path.exists(testing_data_dir): os.mkdir(testing_data_dir)
-test_regression_models_dir = os.path.join(testing_data_dir,'regressors')
-test_classification_models_dir = os.path.join(testing_data_dir,'classifiers')
+# find directory containing training summary
+training_summary_yml = os.path.join(models_dir,'training_summary.yml')
 
 def load_classifier_from_yml(yml_file):
     ymlf = open(yml_file,'rb')
@@ -38,15 +36,12 @@ def load_regressor_from_yml(yml_file):
     reg.load_model_data(content)
     return reg
 
-# find directory containing training summary
-dir_path = os.path.dirname(file_path)
-training_summary_yml = os.path.join(dir_path,'training_summary.yml')
-
 def load_classification_models(model_root_dir=classification_models_dir):  
     model_dict = OrderedDict()
     if not os.path.exists(model_root_dir):
         return model_dict
     all_sys_cls = os.listdir(model_root_dir)
+    # this next line filters out hidden files
     all_sys_cls = [i for i in all_sys_cls if not i[0]=='.']
 
     # the top-level classifier is a collection of classifiers;
@@ -56,6 +51,7 @@ def load_classification_models(model_root_dir=classification_models_dir):
     model_dict['main_classifiers'] = {}
     if os.path.exists(main_cls_path):
         all_main_cls = os.listdir(main_cls_path)
+        # this next line filters out hidden files
         all_main_cls = [i for i in all_main_cls if not i[0]=='.']
         all_main_cls = [cl for cl in all_main_cls if cl.endswith('.yml')]
         for cl in all_main_cls:
@@ -105,6 +101,7 @@ def load_regression_models(model_root_dir=regression_models_dir):
         return model_dict
 
     all_sys_cls = os.listdir(model_root_dir)
+    # this next line filters out hidden files
     all_sys_cls = [i for i in all_sys_cls if not i[0]=='.']
     for sys_cls in all_sys_cls:
         model_dict[sys_cls] = {}
@@ -139,6 +136,7 @@ def load_regression_models(model_root_dir=regression_models_dir):
                 if os.path.exists(stg_dir):
                     model_dict[sys_cls][pop_id][stg_nm] = {}
                     all_stg_labels = os.listdir(stg_dir)
+                    # this next line filters out hidden files
                     all_stg_labels = [i for i in all_stg_labels if not i[0]=='.']
                     for stg_label in all_stg_labels:
                         stg_label_dir = os.path.join(stg_dir,stg_label)
@@ -164,6 +162,7 @@ def load_regression_models(model_root_dir=regression_models_dir):
                     if os.path.exists(stg_dir): 
                         model_dict[sys_cls][pop_id][ff_nm][stg_nm] = {}
                         all_stg_labels = os.listdir(stg_dir)
+                        # this next line filters out hidden files
                         all_stg_labels = [i for i in all_stg_labels if not i[0]=='.']
                         for stg_label in all_stg_labels:
                             stg_label_dir = os.path.join(stg_dir,stg_label)

--- a/xrsdkit/models/__init__.py
+++ b/xrsdkit/models/__init__.py
@@ -10,7 +10,7 @@ from .classifier import Classifier
 file_path = os.path.abspath(__file__)
 models_dir = os.path.dirname(file_path)
 package_dir = os.path.dirname(models_dir)
-#root_dir = os.path.dirname(package_dir)
+root_dir = os.path.dirname(package_dir)
 
 # find directory containing packaged modeling data
 modeling_data_dir = os.path.join(package_dir,'models','modeling_data')

--- a/xrsdkit/models/classifier.py
+++ b/xrsdkit/models/classifier.py
@@ -136,6 +136,9 @@ class Classifier(XRSDModel):
             result += (matrix[ilabel]+"  "+str(label)+'\n')
         return result
 
+    def get_cv_summary(self):
+        return {k:self.cross_valid_results.get(k,None) for k in ['f1_macro','accuracy','precision','recall']} 
+
     def print_CV_report(self):
         """Return a string describing the model's cross-validation metrics.
 

--- a/xrsdkit/models/predict.py
+++ b/xrsdkit/models/predict.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from . import regression_models, classification_models#, test_regression_models, test_classification_models
+from . import regression_models, classification_models
 from ..system import System
 from .. import definitions as xrsdefs
 

--- a/xrsdkit/models/predict.py
+++ b/xrsdkit/models/predict.py
@@ -42,7 +42,7 @@ def predict(features):
             if struct_result[0]:
                 if flagged_structures: flagged_structures += '__'
                 flagged_structures += struct_nm
-        if flagged_structures:
+        if flagged_structures in main_cls:
             sys_cls_result = main_cls[flagged_structures].classify(features)
             sys_cls = sys_cls_result[0]
             certainties['system_class'] = sys_cls_result[1]

--- a/xrsdkit/models/regressor.py
+++ b/xrsdkit/models/regressor.py
@@ -56,7 +56,7 @@ class Regressor(XRSDModel):
         epsilon = 0.15 
         if 'epsilon' in model_hyperparams: epsilon = model_hyperparams['epsilon']
         new_model = linear_model.SGDRegressor(alpha=alpha, l1_ratio=l1_ratio, epsilon=epsilon,
-            loss='huber', penalty='elasticnet', max_iter=10000)
+            loss='huber', penalty='elasticnet', max_iter=10000, tol=1.E-3)
         return new_model
 
     def load_model_data(self,model_data):

--- a/xrsdkit/models/regressor.py
+++ b/xrsdkit/models/regressor.py
@@ -111,6 +111,9 @@ class Regressor(XRSDModel):
         else:
             return self.default_val
 
+    def get_cv_summary(self):
+        return {k:self.cross_valid_results.get(k,None) for k in ['MAE','coef_of_determination']} 
+
     def print_CV_report(self):
         """Return a string describing the model's cross-validation metrics.
 

--- a/xrsdkit/models/train.py
+++ b/xrsdkit/models/train.py
@@ -16,9 +16,7 @@ def train_from_dataframe(data, output_dir, train_hyperparameters=False, select_f
     old_summary = {}
     if os.path.isfile(training_summary_yml): 
         with open(training_summary_yml,'rb') as yml_file:
-            old_results = yaml.load(yml_file)
-    # regression models:
-    reg_models = train_regression_models(data, train_hyperparameters, select_features)
+            old_summary = yaml.load(yml_file)
     # classification models: 
     cls_models = train_classification_models(data, train_hyperparameters, select_features)
     # regression models:
@@ -33,7 +31,7 @@ def train_from_dataframe(data, output_dir, train_hyperparameters=False, select_f
         if not os.path.exists(reg_dir): os.mkdir(reg_dir)
         summary_reg = save_regression_models(reg_dir, reg_models)
         summary_cl = save_classification_models(cl_dir, cls_models)
-        summary = collect_summary(old_results, summary_reg, summary_cl)
+        summary = collect_summary(old_summary, summary_reg, summary_cl)
         yml_f = os.path.join(output_dir,'training_summary.yml')
         with open(yml_f,'w') as yml_file:
             yaml.dump(summary,yml_file)
@@ -79,8 +77,8 @@ def train_classification_models(data,train_hyperparameters=False,select_features
         and (classification_models['main_classifiers'][model_id].trained) \
         and (classification_models['main_classifiers'][model_id].model_type == new_model_type):
             old_pars = classification_models['main_classifiers'][model_id].model.get_params()
-            # TODO: this must respect new_model_type!!!
-            model.model.set_params(C=old_pars['C'])
+            for param_nm in model.models_and_params[new_model_type]:
+                model.model.set_params(**{param_nm:old_pars[param_nm]})
         # binary classifiers should be trained to avoid false positives:
         # use 'precision' as the scoring function
         model.train(data_copy, 'precision', train_hyperparameters, select_features)
@@ -121,8 +119,8 @@ def train_classification_models(data,train_hyperparameters=False,select_features
                 and (classification_models['main_classifiers'][model_id].trained) \
                 and (classification_models['main_classifiers'][model_id].model_type == new_model_type):
                     old_pars = classification_models['main_classifiers'][model_id].model.get_params()
-                    # TODO: this must respect new_model_type!!!
-                    model.model.set_params(C=old_pars['C'])
+                    for param_nm in model.models_and_params[new_model_type]:
+                        model.model.set_params(**{param_nm:old_pars[param_nm]})
                 # system classifiers should use f1_macro or accuracy
                 model.train(flag_data, 'accuracy', train_hyperparameters, select_features)
                 if model.trained:
@@ -156,8 +154,8 @@ def train_classification_models(data,train_hyperparameters=False,select_features
         and (classification_models[sys_cls]['noise_model'].trained) \
         and (classification_models[sys_cls]['noise_model'].model_type == new_model_type):
             old_pars = classification_models[sys_cls]['noise_model'].model.get_params()
-            # TODO: this must respect new_model_type!!!
-            model.model.set_params(C=old_pars['C'])
+            for param_nm in model.models_and_params[new_model_type]:
+                model.model.set_params(**{param_nm:old_pars[param_nm]})
         model.train(sys_cls_data, 'accuracy', train_hyperparameters, select_features)
         if model.trained:
             f1_score = model.cross_valid_results['f1_macro']
@@ -186,8 +184,8 @@ def train_classification_models(data,train_hyperparameters=False,select_features
             and (classification_models[sys_cls][pop_id]['form'].trained) \
             and (classification_models[sys_cls][pop_id]['form'].model_type == new_model_type):
                 old_pars = classification_models[sys_cls][pop_id]['form'].model.get_params()
-                # TODO: this must respect new_model_type!!!
-                model.model.set_params(C=old_pars['C'])
+                for param_nm in model.models_and_params[new_model_type]:
+                    model.model.set_params(**{param_nm:old_pars[param_nm]})
             model.train(sys_cls_data, 'accuracy', train_hyperparameters, select_features)
             if model.trained:
                 f1_score = model.cross_valid_results['f1_macro']
@@ -211,8 +209,8 @@ def train_classification_models(data,train_hyperparameters=False,select_features
                 and (classification_models[sys_cls][pop_id][stg_nm].trained) \
                 and (classification_models[sys_cls][pop_id][stg_nm].model_type == new_model_type):
                     old_pars = classification_models[sys_cls][pop_id][stg_nm].model.get_params()
-                    # TODO: this must respect new_model_type!!!
-                    model.model.set_params(C=old_pars['C'])
+                    for param_nm in model.models_and_params[new_model_type]:
+                        model.model.set_params(**{param_nm:old_pars[param_nm]})
                 model.train(sys_cls_data, 'accuracy', train_hyperparameters, select_features)
                 if model.trained:
                     f1_score = model.cross_valid_results['f1_macro']
@@ -242,8 +240,8 @@ def train_classification_models(data,train_hyperparameters=False,select_features
                     and (classification_models[sys_cls][pop_id][ff][stg_nm].trained) \
                     and (classification_models[sys_cls][pop_id][ff][stg_nm].model_type == new_model_type):
                         old_pars = classification_models[sys_cls][pop_id][ff][stg_nm].model.get_params()
-                        # TODO: this must respect new_model_type!!!
-                        model.model.set_params(C=old_pars['C'])
+                        for param_nm in model.models_and_params[new_model_type]:
+                            model.model.set_params(**{param_nm:old_pars[param_nm]})
                     model.train(form_data, 'accuracy', train_hyperparameters, select_features)
                     if model.trained:
                         f1_score = model.cross_valid_results['f1_macro']
@@ -384,8 +382,8 @@ def train_regression_models(data,train_hyperparameters=False,select_features=Fal
                     and (regression_models[sys_cls]['noise'][modnm][pnm].trained) \
                     and (regression_models[sys_cls]['noise'][modnm][pnm].model_type == new_model_type): 
                         old_pars = regression_models[sys_cls]['noise'][modnm][pnm].model.get_params()
-                        # TODO: this must respect new_model_type!!!
-                        model.model.set_params(alpha=old_pars['alpha'])
+                        for param_nm in model.models_and_params[new_model_type]:
+                            model.model.set_params(**{param_nm:old_pars[param_nm]})
                     model.train(noise_model_data, 'neg_mean_absolute_error', train_hyperparameters, select_features)
                     if model.trained:
                         grpsz_wtd_mean_MAE = model.cross_valid_results['groupsize_weighted_average_MAE']
@@ -410,8 +408,8 @@ def train_regression_models(data,train_hyperparameters=False,select_features=Fal
             and (regression_models[sys_cls][pop_id]['I0_fraction'].trained) \
             and (regression_models[sys_cls][pop_id]['I0_fraction'].model_type == new_model_type): 
                 old_pars = regression_models[sys_cls][pop_id]['I0_fraction'].model.get_params()
-                # TODO: this must respect new_model_type!!!
-                model.model.set_params(alpha=old_pars['alpha'])
+                for param_nm in model.models_and_params[new_model_type]:
+                    model.model.set_params(**{param_nm:old_pars[param_nm]})
             model.train(sys_cls_data, 'neg_mean_absolute_error', train_hyperparameters, select_features)
             if model.trained:
                 grpsz_wtd_mean_MAE = model.cross_valid_results['groupsize_weighted_average_MAE']
@@ -442,8 +440,8 @@ def train_regression_models(data,train_hyperparameters=False,select_features=Fal
                         and (regression_models[sys_cls][pop_id][stg_nm][stg_label][pnm].trained) \
                         and (regression_models[sys_cls][pop_id][stg_nm][stg_label][pnm].model_type == new_model_type):
                             old_pars = regression_models[sys_cls][pop_id][stg_nm][stg_label][pnm].model.get_params()
-                            # TODO: this must respect new_model_type!!!
-                            model.model.set_params(alpha=old_pars['alpha'])
+                            for param_nm in model.models_and_params[new_model_type]:
+                                model.model.set_params(**{param_nm:old_pars[param_nm]})
                         model.train(stg_label_data, 'neg_mean_absolute_error', train_hyperparameters, select_features)
                         if model.trained:
                             grpsz_wtd_mean_MAE = model.cross_valid_results['groupsize_weighted_average_MAE']
@@ -473,8 +471,8 @@ def train_regression_models(data,train_hyperparameters=False,select_features=Fal
                     and (regression_models[sys_cls][pop_id][form_id][pnm].trained) \
                     and (regression_models[sys_cls][pop_id][form_id][pnm].model_type == new_model_type):
                         old_pars = regression_models[sys_cls][pop_id][form_id][pnm].model.get_params()
-                        # TODO: this must respect new_model_type!!!
-                        model.model.set_params(alpha=old_pars['alpha'])
+                        for param_nm in model.models_and_params[new_model_type]:
+                            model.model.set_params(**{param_nm:old_pars[param_nm]})
                     model.train(form_data, 'neg_mean_absolute_error', train_hyperparameters, select_features)
                     if model.trained:
                         grpsz_wtd_mean_MAE = model.cross_valid_results['groupsize_weighted_average_MAE']
@@ -506,8 +504,8 @@ def train_regression_models(data,train_hyperparameters=False,select_features=Fal
                             and (regression_models[sys_cls][pop_id][form_id][stg_nm][stg_label][pnm].trained) \
                             and (regression_models[sys_cls][pop_id][form_id][stg_nm][stg_label][pnm].model_type == new_model_type):
                                 old_pars = regression_models[sys_cls][pop_id][form_id][stg_nm][stg_label][pnm].model.get_params()
-                                # TODO: this must respect new_model_type!!!
-                                model.model.set_params(alpha=old_pars['alpha'])
+                                for param_nm in model.models_and_params[new_model_type]:
+                                    model.model.set_params(**{param_nm:old_pars[param_nm]})
                             model.train(stg_label_data, 'neg_mean_absolute_error', train_hyperparameters, select_features)
                             if model.trained:
                                 grpsz_wtd_mean_MAE = model.cross_valid_results['groupsize_weighted_average_MAE']
@@ -636,7 +634,7 @@ def collect_summary(old_summary, summary_reg, summary_cl):
             summary['REGRESSORS'][k] = {}
             for metric, value in v.items():
                 try:
-                    diff = value-old_results['REGRESSORS'][k][metric][0]
+                    diff = value-old_summary['REGRESSORS'][k][metric][0]
                 except:
                     diff = None
                 summary['REGRESSORS'][k][metric] = [value, diff]
@@ -646,7 +644,7 @@ def collect_summary(old_summary, summary_reg, summary_cl):
         if v:
             for metric, value in v.items():
                 try:
-                    diff = value-old_results['CLASSIFIERS'][k][metric][0]
+                    diff = value-old_summary['CLASSIFIERS'][k][metric][0]
                 except:
                     diff = None
                 summary['CLASSIFIERS'][k][metric] = [value, diff]

--- a/xrsdkit/models/xrsd_model.py
+++ b/xrsdkit/models/xrsd_model.py
@@ -17,7 +17,7 @@ class XRSDModel(object):
         self.models_and_params = {}
         self.model = None
         self.scaler = preprocessing.StandardScaler()
-        self.cross_valid_results = None
+        self.cross_valid_results = {} 
         self.target = label
         self.trained = False
         self.default_val = None

--- a/xrsdkit/tools/devtools.py
+++ b/xrsdkit/tools/devtools.py
@@ -1,4 +1,5 @@
 import os
+
 from .ymltools import read_local_dataset, load_models
 from ..db import gather_remote_dataset
 from ..models.train import train_from_dataframe

--- a/xrsdkit/tools/visualization_tools.py
+++ b/xrsdkit/tools/visualization_tools.py
@@ -18,11 +18,6 @@ def plot_2d(data, axis_cols, label, show_plot=True):
         column name to use for plot labeling
     show_plot : bool
         whether or not to show the plot on the display
-    save_plot : bool
-        If True, plot will be saved to
-        `saving_dir`/`label`_wrt_`axis_cols[0]`_by_`axis_cols[1]`.png
-    saving_dir : str
-        directory to save the plot
     """
     groups = data.groupby(label)
 
@@ -38,13 +33,8 @@ def plot_2d(data, axis_cols, label, show_plot=True):
     ax.set_title('By ' + label)
     ax.legend(bbox_to_anchor=(1.05, 1), loc=2,
            ncol=1,  borderaxespad=0.)
-
     if show_plot:
         plt.show(block=False)
-
-    if save_plot:
-        file_name=label+'_wrt_'+axis_cols[0]+'_by_'+axis_cols[1]+'.png'
-        fig.savefig(os.path.join(saving_dir,file_name))
 
 def doPCA(data, n_dimensions):
     """Perform principal component analysis on DataFrame `data`.

--- a/xrsdkit/tools/visualization_tools.py
+++ b/xrsdkit/tools/visualization_tools.py
@@ -2,12 +2,7 @@ import os
 from sklearn.decomposition import PCA
 import matplotlib.pyplot as plt
 
-def plot_2d(data,
-    axis_cols,
-    label,
-    show_plot=True,
-    save_plot=False,
-    saving_dir=None):
+def plot_2d(data, axis_cols, label, show_plot=True):
     """Make a labeled scatterplot of any two columns of the data.
 
     Optionally, the plot can be shown on the display 

--- a/xrsdkit/visualization/__init__.py
+++ b/xrsdkit/visualization/__init__.py
@@ -4,19 +4,13 @@ from matplotlib import pyplot as plt
 from ..tools.visualization_tools import doPCA, plot_2d
 from ..tools import profiler
 
-default_targets=['system_class','experiment_id']
-
-file_path = os.path.abspath(__file__)
-src_dir = os.path.dirname(os.path.dirname(file_path))
-saving_dir  = os.path.join(src_dir,'models','modeling_data','test')
-
-def plot_xrsd_fit(sys=None,q=None,I=None,dI=None,show_plot=False):
+def plot_xrsd_fit(sys=None, q=None, I=None, dI=None, show_plot=False):
     mpl_fig = plt.figure() 
     ax_plot = mpl_fig.add_subplot(111)
     I_comp = draw_xrsd_fit(mpl_fig,sys,q,I,dI,show_plot)
     return mpl_fig, I_comp
 
-def draw_xrsd_fit(mpl_fig,sys=None,q=None,I=None,dI=None,show_plot=False):
+def draw_xrsd_fit(mpl_fig, sys=None, q=None, I=None, dI=None, show_plot=False):
     ax_plot = mpl_fig.gca()
     ax_plot.clear()
     legend_entries = []
@@ -42,14 +36,8 @@ def draw_xrsd_fit(mpl_fig,sys=None,q=None,I=None,dI=None,show_plot=False):
         mpl_fig.show()
     return I_comp
 
-def visualize_dataframe(data,
-    labels = default_targets,
-    features = profiler.profile_keys,
-    use_pca = True,
-    pca_comp_to_use = [0,1],
-    show_plots = False,
-    save_plots = False,
-    saving_dir = saving_dir):
+def visualize_dataframe(data, labels=['system_class'], features=profiler.profile_keys,
+                        use_pca=True, pca_comp_to_use=[0,1], show_plots = False):
     """Makes a labeled scatterplot of data. 
 
     If use_pca is True,
@@ -78,11 +66,6 @@ def visualize_dataframe(data,
         Each index must be less than the total number of features
     show_plots : bool
         whether or not to show the plots on the display
-    save_plots : bool
-        If True, plots for each label will be saved to
-        `saving_dir` / `label` _wrt_(feature_or_PC_0)_by_(feature_or_PC_1).png
-    saving_dir : str
-        directory to save the plots
     """
     if use_pca:
         pca = doPCA(data[features], n_dimensions=len(features))
@@ -93,7 +76,6 @@ def visualize_dataframe(data,
     else:
         columns_to_vis = features[:2]
     for label in labels:
-        plot_2d(data, columns_to_vis, label,
-                False, save_plots, saving_dir)
+        plot_2d(data, columns_to_vis, label, False)
     if show_plots:
         plt.show(block=False)


### PR DESCRIPTION
A few small things:
- Minor cleanup everywhere
- Unified classifier summaries into a single dict
- Implemented get_cv_summary() as instance method for Regressor and Classifier

One major fix (unrelated to "summary"):
In #193 I failed to respect the model_type when loading parameters from previously trained models. I think I have fixed it here. 

One more minor fix (also unrelated to "summary"):
When the binary classifiers predict a subset of structures that do not exist in the training set, there is no system_classifier to follow it. In this case, I have allowed it to return "unidentified" instead of raising a KeyError. Again, not related to "summary".