### PR TITLE
Feature migrations

### DIFF
--- a/xrsdkit/tools/devtools.py
+++ b/xrsdkit/tools/devtools.py
@@ -1,7 +1,7 @@
 import os
 
 from .ymltools import read_local_dataset, load_models
-from .ymltools import update_features_for_local_dataset
+from .ymltools import migrate_features
 from ..db import gather_remote_dataset
 from ..models.train import train_from_dataframe
 from ..models import modeling_data_dir, load_models
@@ -21,7 +21,4 @@ def dataset_to_csv(dataset_dir,downsampling_distance=1.):
 
 def update_models(models_dir):
     load_models(models_dir, modeling_data_dir)
-
-def update_features(dataset_dir):
-    update_features_for_local_dataset(dataset_dir) 
 

--- a/xrsdkit/tools/devtools.py
+++ b/xrsdkit/tools/devtools.py
@@ -1,6 +1,6 @@
 import os
 
-from .ymltools import read_local_dataset, load_models
+from .ymltools import read_local_dataset
 from .ymltools import migrate_features
 from ..db import gather_remote_dataset
 from ..models.train import train_from_dataframe

--- a/xrsdkit/tools/devtools.py
+++ b/xrsdkit/tools/devtools.py
@@ -1,6 +1,7 @@
 import os
 
-from .ymltools import read_local_dataset
+from .ymltools import read_local_dataset, load_models
+from .ymltools import update_features_for_local_dataset
 from ..db import gather_remote_dataset
 from ..models.train import train_from_dataframe
 from ..models import modeling_data_dir, load_models
@@ -20,4 +21,7 @@ def dataset_to_csv(dataset_dir,downsampling_distance=1.):
 
 def update_models(models_dir):
     load_models(models_dir, modeling_data_dir)
+
+def update_features(dataset_dir):
+    update_features_for_local_dataset(dataset_dir) 
 

--- a/xrsdkit/tools/ymltools.py
+++ b/xrsdkit/tools/ymltools.py
@@ -1,6 +1,9 @@
 from collections import OrderedDict
 import os
+import sys
 import copy
+from distutils.dir_util import copy_tree
+import shutil
 
 from sklearn import preprocessing
 import pandas as pd
@@ -75,8 +78,7 @@ def migrate_features(data_dir):
             sys = load_sys_from_yaml(file_path)
             q_I = np.loadtxt(os.path.join(data_dir,sys.sample_metadata['data_file']))
             sys.features = profiler.profile_pattern(q_I[:,0],q_I[:,1])
-            #save_sys_to_yaml(file_path,sys)
-            #if bool(int(sys.fit_report['good_fit'])):
+            save_sys_to_yaml(file_path,sys)
     print('FINISHED FEATURE MIGRATION')
 
 
@@ -387,3 +389,14 @@ def downsample(df, min_distance):
 
         sample = sample.append(df.iloc[sample_order])
     return sample
+
+def load_models(models_dir, modeling_data_dir):
+    print('Loading models from '+models_dir)
+    cl_dir = os.path.join(modeling_data_dir,'classifiers')
+    reg_dir = os.path.join(modeling_data_dir,'regressors')
+    summary = os.path.join(modeling_data_dir,'training_summary.yml')
+    shutil.rmtree(cl_dir)
+    shutil.rmtree(reg_dir)
+    os.remove(summary)
+    copy_tree(models_dir, modeling_data_dir)
+    print("Done!")

--- a/xrsdkit/tools/ymltools.py
+++ b/xrsdkit/tools/ymltools.py
@@ -59,32 +59,25 @@ def read_local_dataset(dataset_dir,downsampling_distance=None):
     df = create_modeling_dataset(list(sys_dicts.values()),downsampling_distance=downsampling_distance)
     return df 
 
-def migrate_features_for_local_dataset(dataset_dir):
-    """Update features for all samples in a local dataset.
-
-    TODO: refer to dataset description in main docs
-    (see docstring for read_local_datset())
+def migrate_features(data_dir):
+    """Update features for all yml files in a local directory.
 
     Parameters
     ----------
-    dataset_dir : str
-        absolute path to the root directory of the dataset
+    data_dir : str
+        absolute path to the directory containing yml data 
     """
-    print('BEGINNING FEATURE MIGRATION FOR DATASET AT {}'.format(dataset_dir))
-    for experiment in os.listdir(dataset_dir):
-        exp_data_dir = os.path.join(dataset_dir,experiment)
-        if os.path.isdir(exp_data_dir):
-            for s_data_file in os.listdir(exp_data_dir):
-                if s_data_file.endswith('.yml'):
-                    print('loading data from {}'.format(s_data_file))
-                    file_path = os.path.join(exp_data_dir, s_data_file)
-                    sys = load_sys_from_yaml(file_path)
-                    q_I = np.loadtxt(os.path.join(exp_data_dir,sys.sample_metadata['data_file']))
-                    sys.features = profiler.profile_pattern(q_I[:,0],q_I[:,1])
-                    save_sys_to_yaml(file_path,sys)
-                    #if bool(int(sys.fit_report['good_fit'])):
+    print('BEGINNING FEATURE MIGRATION FOR DIRECTORY: {}'.format(data_dir))
+    for s_data_file in os.listdir(data_dir):
+        if s_data_file.endswith('.yml'):
+            print('loading data from {}'.format(s_data_file))
+            file_path = os.path.join(data_dir, s_data_file)
+            sys = load_sys_from_yaml(file_path)
+            q_I = np.loadtxt(os.path.join(data_dir,sys.sample_metadata['data_file']))
+            sys.features = profiler.profile_pattern(q_I[:,0],q_I[:,1])
+            #save_sys_to_yaml(file_path,sys)
+            #if bool(int(sys.fit_report['good_fit'])):
     print('FINISHED FEATURE MIGRATION')
-    
 
 
 def create_modeling_dataset(xrsd_system_dicts,downsampling_distance=None):

--- a/xrsdkit/tools/ymltools.py
+++ b/xrsdkit/tools/ymltools.py
@@ -390,13 +390,3 @@ def downsample(df, min_distance):
         sample = sample.append(df.iloc[sample_order])
     return sample
 
-def load_models(models_dir, modeling_data_dir):
-    print('Loading models from '+models_dir)
-    cl_dir = os.path.join(modeling_data_dir,'classifiers')
-    reg_dir = os.path.join(modeling_data_dir,'regressors')
-    summary = os.path.join(modeling_data_dir,'training_summary.yml')
-    shutil.rmtree(cl_dir)
-    shutil.rmtree(reg_dir)
-    os.remove(summary)
-    copy_tree(models_dir, modeling_data_dir)
-    print("Done!")

--- a/xrsdkit/visualization/gui.py
+++ b/xrsdkit/visualization/gui.py
@@ -37,6 +37,10 @@ def run_fit_gui(data_files={}):
     gui = XRSDFitGUI(data_files)
     gui.start()
 
+# TODO (high): update IO - assume yml and dat files are in same directory
+# TODO (high): update IO - create minimal yml file if nonexistent, with same name as dat file 
+# TODO (high): update IO - assign the sample_metadata['data_file'] attribute if empty or incorrect
+
 # TODO (low): when a selection is rejected (raises an Exception),
 #   get the associated combobox re-painted-
 #   currently the value does get reset, 


### PR DESCRIPTION
The code for this feature is pretty simple. Given a dataset directory, it reads all yml files, and then:
- builds the System object from the yml
- uses the sys.sample_metadata to find the data (q,I) file
- reads the q,I array and recomputes the features
- assigns the new features to the sys.features dict
- re-saves the System object in the same yml file

The dataset itself has more significant changes. I am now assuming that all .dat and .yml files are in the same directory, and the .yml file must know the name of its corresponding .dat file. I corrected both of our modeling datasets to obey these new rules. 

Note, the IO strategy for the GUI can be simplified with this in mind- I will do that soon.

Note also, I did not __yet__ change the features themselves. That will come later-- this is just a tool to make feature changes easier to execute.

Note also, it is tempting to just put the q,I arrays in the yml file, but I think this will be a bad idea when xrsdkit starts to work for 2d patterns (the yml files will become very, very large).