### PR TITLE
updated setup and requirements files to fix sklearn<->dask issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy
 scipy
 pandas
 lmfit
-scikit-learn>0.19.0
+scikit-learn<0.21.0
 matplotlib
 dask_ml
 pygresql

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from setuptools import setup, find_packages
 setup(name='xrsdkit',
     version='0.1.2',
     url='https://github.com/scattering-central/xrsdkit.git',
-    description='Scattering and diffraction analysis and modeling toolkit',
+    description='Scattering and diffraction modeling and analysis toolkit',
     author='SSRL',
     license='BSD',
     author_email='paws-developers@slac.stanford.edu',
-    install_requires=['pyyaml','numpy','scipy','pandas','scikit-learn','lmfit'],
+    install_requires=['pyyaml','numpy','scipy','pandas','scikit-learn<0.21.0','lmfit','matplotlib','dask_ml','paramiko'],
     packages=find_packages(),
-    package_data={'xrsdkit':['scattering/*.yml','models/modeling_data/*.yml']}
+    package_data={'xrsdkit':['scattering/*.yml','models/modeling_data/*']}
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='xrsdkit',
     author_email='paws-developers@slac.stanford.edu',
     install_requires=['pyyaml','numpy','scipy','pandas','scikit-learn<0.21.0','lmfit','matplotlib','dask_ml','paramiko'],
     packages=find_packages(),
-    package_data={'xrsdkit':['scattering/*.yml','models/modeling_data/*']}
+    package_data={'xrsdkit':['scattering/*.yml']}
     )
 
 


### PR DESCRIPTION
This is mostly to fix the sklearn vs. dask import bug, but I also added the rest of the requirements to setup.py, and removed the modeling_data directory since we are no longer packaging the models.