### PR TITLE
can now plot xrsd fits by passing axes objects

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -2,6 +2,7 @@ import os
 import copy
 
 import numpy as np
+from matplotlib import pyplot as plt
 
 from xrsdkit.system import System, fit 
 from xrsdkit.visualization import plot_xrsd_fit, draw_xrsd_fit
@@ -31,7 +32,21 @@ q_I = np.loadtxt(open(datapath,'r'),dtype=float)
 
 def test_plot():
     if 'DISPLAY' in os.environ:
-        mpl_fig,I_comp = plot_xrsd_fit(np_sys,q_I[:,0],q_I[:,1],True) 
+        mpl_fig,I_comp = plot_xrsd_fit(np_sys,q_I[:,0],q_I[:,1]) 
         opt_np_sys = fit(np_sys,q_I[:,0],q_I[:,1])
-        draw_xrsd_fit(mpl_fig,opt_np_sys,q_I[:,0],q_I[:,1],True)
+        draw_xrsd_fit(mpl_fig.gca(),opt_np_sys,q_I[:,0],q_I[:,1])
+        mpl_fig.show()
+
+def test_multipanel_plot():
+    if 'DISPLAY' in os.environ:
+        fig, ax = plt.subplots(2,2)
+        draw_xrsd_fit(ax[0,0],np_sys,q_I[:,0],q_I[:,1])
+        draw_xrsd_fit(ax[0,1],np_sys,q_I[:,0],q_I[:,1])
+        draw_xrsd_fit(ax[1,0],np_sys,q_I[:,0],q_I[:,1])
+        draw_xrsd_fit(ax[1,1],np_sys,q_I[:,0],q_I[:,1])
+        ax[0,0].set_xlabel('')
+        ax[0,1].set_xlabel('')
+        ax[0,1].set_ylabel('')
+        ax[1,1].set_ylabel('')
+        plt.show()
 

--- a/xrsdkit/visualization/__init__.py
+++ b/xrsdkit/visualization/__init__.py
@@ -7,33 +7,32 @@ from ..tools import profiler
 def plot_xrsd_fit(sys=None, q=None, I=None, dI=None, show_plot=False):
     mpl_fig = plt.figure() 
     ax_plot = mpl_fig.add_subplot(111)
-    I_comp = draw_xrsd_fit(mpl_fig,sys,q,I,dI,show_plot)
+    I_comp = draw_xrsd_fit(ax_plot,sys,q,I,dI)
+    if show_plot:
+        mpl_fig.show()
     return mpl_fig, I_comp
 
-def draw_xrsd_fit(mpl_fig, sys=None, q=None, I=None, dI=None, show_plot=False):
-    ax_plot = mpl_fig.gca()
-    ax_plot.clear()
+def draw_xrsd_fit(mpl_axes, sys=None, q=None, I=None, dI=None):
+    mpl_axes.clear()
     legend_entries = []
     if q is not None and I is not None:
-        ax_plot.semilogy(q,I,lw=2,color='black')
+        mpl_axes.semilogy(q,I,lw=2,color='black')
         legend_entries.append('measured')
     I_comp = None
     if sys and q is not None:
         I_comp = sys.compute_intensity(q)
-        ax_plot.semilogy(q,I_comp,lw=2,color='red')
+        mpl_axes.semilogy(q,I_comp,lw=2,color='red')
         legend_entries.append('computed')
         I_noise = sys.noise_model.compute_intensity(q)
-        ax_plot.semilogy(q,I_noise,lw=1) 
+        mpl_axes.semilogy(q,I_noise,lw=1) 
         legend_entries.append('noise')
         for popnm,pop in sys.populations.items():
             I_p = pop.compute_intensity(q,sys.sample_metadata['source_wavelength'])
-            ax_plot.semilogy(q,I_p,lw=1)
+            mpl_axes.semilogy(q,I_p,lw=1)
             legend_entries.append(popnm)
-    ax_plot.set_xlabel('q (1/Angstrom)')
-    ax_plot.set_ylabel('Intensity (counts)')
-    ax_plot.legend(legend_entries)
-    if show_plot:
-        mpl_fig.show()
+    mpl_axes.set_xlabel('q (1/Angstrom)')
+    mpl_axes.set_ylabel('Intensity (counts)')
+    mpl_axes.legend(legend_entries)
     return I_comp
 
 def visualize_dataframe(data, labels=['system_class'], features=profiler.profile_keys,

--- a/xrsdkit/visualization/gui.py
+++ b/xrsdkit/visualization/gui.py
@@ -1112,7 +1112,7 @@ class XRSDFitGUI(object):
         #return npf
 
     def _draw_plots(self):
-        I_comp = draw_xrsd_fit(self.fig,self.sys,self.q,self.I,self.dI,False)
+        I_comp = draw_xrsd_fit(self.fig.gca(),self.sys,self.q,self.I,self.dI)
         self.mpl_canvas.draw()
         self._update_fit_objective(I_comp)
 


### PR DESCRIPTION
This PR changes the functionality of draw_xrsd_fit(). It now takes a matplotlib Axes object as the first input.

For an example of a multi-frame plot, see the new test in tests/test_plots.py.

Depending on how you want the multi-frame plot to look, you may need to set several properties of the Axes objects after calling draw_xrsd_fit() on them. In the test, for example, I removed the extraneous x-axis and y-axis labels.