### PR TITLE
refactored predict() functions

### DIFF
--- a/xrsdkit/models/classifier.py
+++ b/xrsdkit/models/classifier.py
@@ -99,15 +99,15 @@ class Classifier(XRSDModel):
                 max_iter=1000, tol=1.E-3, class_weight='balanced')
         return new_model
 
-    def predict_all(self,data):
-        """Run predictions for each row of input `data`.
+    def predict(self,data):
+        """Run predictions for input array-like `data`.
 
         Each row of `data` represents one sample.
         The `data` columns are assumed to match self.features.
 
         Parameters
         ----------
-        data : array
+        data : array-like
         
         Returns
         -------
@@ -122,43 +122,13 @@ class Classifier(XRSDModel):
             certs = np.zeros(data.shape[0])
         return preds, certs 
 
-    def classify(self, sample_features):
-        """Classify the model target for one sample.
-
-        Parameters
-        ----------
-        sample_features : OrderedDict
-            OrderedDict of features with their values,
-            similar to output of xrsdkit.tools.profiler.profile_pattern().
-
-        Returns
-        -------
-        cls : object 
-            Predicted classification value for self.target, given `sample_features`
-        cert : float or None
-            the certainty of the prediction
-            (For models that are not trained, cert=None)
-        """
-        if self.trained:
-            feature_array = np.array(list(sample_features.values())).reshape(1,-1)
-            feature_idx = [k in self.features for k in sample_features.keys()]
-            x = self.scaler.transform(feature_array)[:, feature_idx]
-            cls = self.model.predict(x)[0]
-            try:
-                cert = max(self.model.predict_proba(x)[0])
-            except:
-                cert = None  # the model has no attribute 'predict_proba'
-            return cls, cert
-        else:
-            return (self.default_val,0.)
-
     def cv_report(self,data,y_true,y_pred):
         all_labels = data[self.target].unique().tolist()
-        
         cm = confusion_matrix(y_true, y_pred, all_labels)
-
-        if len(all_labels) == 2 and isinstance(all_labels[0], bool): score_type = "binary"
-        else: score_type = "macro" #self.metric is f1_macro, so we cannot it use directly
+        if len(all_labels) == 2 and isinstance(all_labels[0], bool): 
+            score_type = "binary"
+        else: 
+            score_type = "macro" #self.metric is f1_macro, so we cannot it use directly
         result = dict(
             all_labels = all_labels,
             confusion_matrix = str(cm),
@@ -168,10 +138,14 @@ class Classifier(XRSDModel):
             accuracy = accuracy_score(y_true, y_pred, sample_weight=None)
             )
         #print('f1: {}'.format(result['f1_score']))
-        if "f1" in self.metric: result['minimization_score'] = -1*result['f1']
-        elif "prec" in self.metric: result['minimization_score'] = -1*result['precision']
-        elif "rec" in self.metric: result['minimization_score'] = -1*result['recall']
-        else: result['minimization_score'] = -1*result['accuracy']
+        if "f1" in self.metric: 
+            result['minimization_score'] = -1*result['f1']
+        elif "prec" in self.metric: 
+            result['minimization_score'] = -1*result['precision']
+        elif "rec" in self.metric: 
+            result['minimization_score'] = -1*result['recall']
+        else: 
+            result['minimization_score'] = -1*result['accuracy']
         return result
 
     def group_by_pc1(self,dataframe,feature_names,n_groups=5):

--- a/xrsdkit/models/regressor.py
+++ b/xrsdkit/models/regressor.py
@@ -90,7 +90,7 @@ class Regressor(XRSDModel):
         data[self.target] = self.scaler_y.transform(data[self.target].values.reshape(-1, 1))
         return data
 
-    def predict_all(self,data):
+    def predict(self,data):
         """Run predictions for each row of input `data`.
 
         Each row of `data` represents one sample.
@@ -98,7 +98,7 @@ class Regressor(XRSDModel):
 
         Parameters
         ----------
-        data : array
+        data : array-like
         
         Returns
         -------
@@ -110,28 +110,6 @@ class Regressor(XRSDModel):
         else:
             preds = self.default_val*np.ones(data.shape[0])
         return preds 
-
-    def predict(self, sample_features):
-        """Predict this model's scalar target for one sample. 
-
-        Parameters
-        ----------
-        sample_features : OrderedDict
-            OrderedDict of features with their values,
-            similar to output of xrsdkit.tools.profiler.profile_pattern()
-
-        Returns
-        -------
-        prediction : float
-            predicted parameter value
-        """
-        if self.trained:
-            feature_array = np.array(list(sample_features.values())).reshape(1,-1)
-            feature_idx = [k in self.features for k in sample_features.keys()]
-            x = self.scaler.transform(feature_array)[:, feature_idx]
-            return float(self.scaler_y.inverse_transform(self.model.predict(x))[0])
-        else:
-            return self.default_val
 
     def get_cv_summary(self):
         return dict(model_type=self.model_type,

--- a/xrsdkit/models/train.py
+++ b/xrsdkit/models/train.py
@@ -110,14 +110,11 @@ def cross_validate_system_classifiers(cls_models, data):
         if cls.trained:
             group_ids, training_possible = cls.group_by_pc1(data_copy,profile_keys)
             data_copy['group_id'] = group_ids
-            # TODO: data_copy must be scaled first
-            s_data = data_copy.copy()
-            s_data[cls.features] = cls.scaler.transform(data_copy[cls.features])
-            y_xval = cls._run_cross_validation(cls.model,s_data,cls.features)
+            y_xval = cls.run_cross_validation(data_copy)
         else:
             y_xval = [cls.default_val] * data_copy.shape[0]
         pred.loc[:,model_id+'_xval'] = y_xval
-        y_pred,certs = cls.predict_all(np.array(data_copy[cls.features]))
+        y_pred,certs = cls.predict(data_copy[cls.features])
         pred.loc[:,model_id+'_pr'] = y_pred 
     # For each combination of binary flags, 
     # if the model exists (this combination of flags was in the training set),
@@ -138,7 +135,7 @@ def cross_validate_system_classifiers(cls_models, data):
             if model_id in cls_models['main_classifiers']:
                 cls = cls_models['main_classifiers'][model_id]
                 if cls.trained:
-                    y_pred, certs = cls.predict_all((data_copy.loc[flag_idx,cls.features]))
+                    y_pred, certs = cls.predict(data_copy.loc[flag_idx,cls.features])
                 else:
                     y_pred = [cls.default_val] * np.sum(flag_idx) 
             else:

--- a/xrsdkit/models/xrsd_model.py
+++ b/xrsdkit/models/xrsd_model.py
@@ -267,7 +267,7 @@ class XRSDModel(object):
 
     def get_x_array(self,od):
         """Extract input array from feature dictionary"""
-        return np.array([od[k] for k in self.features])
+        return np.array([od[k] for k in self.features]).reshape(1,-1)
 
     def predict(self,x):
         raise NotImplementedError('XRSDModel subclasses must implement predict()')

--- a/xrsdkit/models/xrsd_model.py
+++ b/xrsdkit/models/xrsd_model.py
@@ -159,7 +159,7 @@ class XRSDModel(object):
             self.model = self.build_model(model_hyperparams)
             self.model.fit(valid_data[self.features], valid_data[self.target])
             y_true = valid_data[self.target].copy()
-            y_xval = self._run_cross_validation(self.model,valid_data,self.features)
+            y_xval = self._cross_validation_test(self.model,valid_data,self.features)
             y_pred = self.model.predict(valid_data[self.features])
             self.cross_valid_results = self.cv_report(valid_data,y_true,y_xval) 
             self.trained = True
@@ -179,7 +179,7 @@ class XRSDModel(object):
         rfe_feats = []
         test_model = self.build_model()
         y_true = data[self.target].copy()
-        y_xval = self._run_cross_validation(test_model,data,model_feats)
+        y_xval = self._cross_validation_test(test_model,data,model_feats)
         cv = self.cv_report(data,y_true,y_xval)
         cv_metrics.append(cv['minimization_score'])
         rfe_feats.append(copy.deepcopy(model_feats))
@@ -194,7 +194,7 @@ class XRSDModel(object):
             for feat in model_feats:
                 trial_feats = copy.deepcopy(model_feats)
                 trial_feats.remove(feat)
-                y_xval = self._run_cross_validation(test_model,data,trial_feats)
+                y_xval = self._cross_validation_test(test_model,data,trial_feats)
                 cv = self.cv_report(data,y_true,y_xval)
                 feat_cv_metrics.append(cv['minimization_score'])
             best_cv_idx = np.argmin(feat_cv_metrics)
@@ -259,7 +259,20 @@ class XRSDModel(object):
         if any([ct<n_distinct for ct in distinct_value_counts]): return False
         return True
 
-    def _run_cross_validation(self,model,data,feature_names):
+    def run_cross_validation(self,data):
+        s_data = data.copy()
+        s_data[self.features] = self.scaler.transform(s_data[self.features])
+        y_xval = self._cross_validation_test(self.model,s_data,self.features)
+        return y_xval
+
+    def get_x_array(self,od):
+        """Extract input array from feature dictionary"""
+        return np.array([od[k] for k in self.features])
+
+    def predict(self,x):
+        raise NotImplementedError('XRSDModel subclasses must implement predict()')
+
+    def _cross_validation_test(self,model,data,feature_names):
         """Cross-validate a model by LeaveOneGroupOut. 
 
         The train/test groupings are defined by the 'group_id' labels,


### PR DESCRIPTION
All models should have a predict() function that behaves the same as the predict() function of the internal sklearn model.

So, every model also gets a new get_x_array() function that extracts an "input" array from a "features" dictionary, based on the model.features list.

Also, we now have a run_cross_validation() function that is safe to use, and the old _run_cross_validation() is now _cross_validation_test().